### PR TITLE
Add ability to set the host secret for trusted agent communication

### DIFF
--- a/AGMPowerCLI.psd1
+++ b/AGMPowerCLI.psd1
@@ -26,7 +26,7 @@
 RootModule = 'AGMPowerCLI.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.0.59'
+ModuleVersion = '0.0.0.61'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -181,6 +181,7 @@ FunctionsToExport = @(
     'Set-AGMConsistencyGroup',
     'Set-AGMConsistencyGroupMember',
     'Set-AGMHostPort',
+    'Set-AGMHostSecret',
     'Set-AGMImage',
     'Set-AGMPromoteUser',
     'Set-AGMTimeZoneHandling',


### PR DESCRIPTION
Function to allow updating secrets on an already existing AGM host, for trusted communication between backup appliance and host. 

This helps with workflows where Backup and DR agents are silently installed (e.g. through startup scripts) and subsequent application discovery, and backup plans will be automated.

The PR attempts to follow the current structure of the simple powershell functions with explicitly checking the parameters in the body.

Functionality:

1. Get the host by id (exit if host does not exist)
2. If host communication is already trusted, i.e. if certificate status is valid, prompt user for confirmation (unless force paramter is set)
3. Add secret value to the host body
4. Request update to the host
5. Return successful response (host object), or output an error message if the secret is not updated correctly.